### PR TITLE
⚙️  refactor useAudioEngine to use a state machine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -269,6 +269,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@cassiozen/usestatemachine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@cassiozen/usestatemachine/-/usestatemachine-1.0.1.tgz",
+      "integrity": "sha512-KWik9Kj+h/Cle/8/4LTF6cWcUslrS3Us9du3JlyneMduiGYx5ZxkdkA+YOS1NxlyMp7Lztb+1cChiTOSh3AntQ=="
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@cassiozen/usestatemachine": "^1.0.1",
     "date-fns": "^2.28.0",
     "dexie": "^3.2.1",
     "preact": "^10.5.15",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 import { useDexie } from 'use-dexie'
 
 import TrackList from './TrackList'
-import useAudioEngine, { Status } from './useAudioEngine'
+import useAudioEngine, { State } from './useAudioEngine'
 
 const DB_NAME = 'REC_DB'
 const DB_SCHEMA = {
@@ -17,7 +17,7 @@ const App = () => {
   return (
     <>
       {/* for debugging */}
-      {process.env.NODE_ENV === 'development' && <div>{Status[status]}</div>}
+      {process.env.NODE_ENV === 'development' && <div>{State[status]}</div>}
       <TrackList onPlay={play} tracks={tracks} />
 
       <button class="record" onClick={toggleRecord}>

--- a/src/components/useAudioEngine.ts
+++ b/src/components/useAudioEngine.ts
@@ -1,5 +1,6 @@
+import useStateMachine, { t } from '@cassiozen/usestatemachine'
 import { format } from 'date-fns'
-import { useEffect, useRef, useState } from 'preact/hooks'
+import { useRef, useState } from 'preact/hooks'
 import { useDexieMap, useDexiePutItem } from 'use-dexie'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -7,58 +8,30 @@ import { Track } from './TrackList'
 
 type ObjectOf<T> = { [key: string]: T }
 type AudioState = ObjectOf<boolean>
+// These trigger transitions between states
+// of the state machine.
+enum Event {
+  AUDIO_READY = 'AUDIO_READY',
+  ERROR = 'ERROR',
+  IDLE = 'IDLE',
+  PLAY = 'PLAY',
+  RECORD = 'RECORD',
+  STOP_RECORDING = 'STOP_RECORDING',
+}
 
-export enum Status {
-  ERROR,
-  FINISHED_RECORDING,
-  IDLE,
-  PLAYING,
-  RECORDING,
-  SAVING_AUDIO,
-  SWITCHING_TRACKS,
-  WAITING_ON_MIC_ACCESS,
+// These are the possible states
+// of the state machine.
+export enum State {
+  ERROR = 'ERROR',
+  FINISHED_RECORDING = 'FINISHED_RECORDING',
+  IDLE = 'IDLE',
+  PLAYING = 'PLAYING',
+  RECORDING = 'RECORDING',
+  SAVING_AUDIO = 'SAVING_AUDIO',
+  WAITING_ON_MIC_ACCESS = 'WAITING_ON_MIC_ACCESS',
 }
 
 const CONSTRAINTS = { audio: true, video: false }
-
-const getStatus = (state: AudioState): Status => {
-  const { audioReady, mediaRecorder, playing, recording, switchTo } = state
-
-  // We aren't doing anything.
-  // No audio is playing, the user isn't waiting for recording to start
-  if (!recording && !mediaRecorder && !playing) return Status.IDLE
-
-  // `recording` gets set to true when the user hits record.
-  // We have to wait for the Promise from getUserMedia to resolve
-  // before we start recording.
-  // It resolves with the actual audio stream
-  if (recording && !mediaRecorder) return Status.WAITING_ON_MIC_ACCESS
-
-  // Once the Promise resolves, mediaRecorder is set
-  // and the engine starts recording audio
-  if (recording && mediaRecorder) return Status.RECORDING
-
-  // When the user stops recording, not all chunks of audio
-  // are ready yet. We have to wait for mediaRecorder.onstop to fire
-  if (!recording && mediaRecorder && !audioReady)
-    return Status.FINISHED_RECORDING
-
-  // After mediaRecorder.onstop fires, we can collect
-  // the audio chunks and produce a finished track
-  if (!recording && mediaRecorder && audioReady) return Status.SAVING_AUDIO
-
-  if (playing && switchTo) return Status.SWITCHING_TRACKS
-
-  if (playing && !switchTo) return Status.PLAYING
-
-  // Something is not right, we should not get here
-  console.error(
-    `undefined state! Here's the state that got us here: ${Object.keys(
-      state
-    ).map((k) => `${k}: ${state[k]}`)}`
-  )
-  return Status.ERROR
-}
 
 const makeTrack = ({
   audio,
@@ -76,140 +49,209 @@ const makeTrack = ({
 
 interface AudioEngine {
   play: (trackId: string) => void
-  status: Status
+  status: State
   toggleRecord: () => void
   tracks: Track[]
 }
 
 const useAudioEngine = (): AudioEngine => {
-  // This is true once we have the final chunk from getUserMedia
-  const [audioReady, setAudioReady] = useState(false)
-  // Holds the stream from getUserMedia once the Promise resolves
-  const [mediaRecorder, setMediaRecorder] = useState<MediaRecorder | null>(null)
-  // Holds the string id if a track is playing
-  const [playing, setPlaying] = useState<string | null>(null)
-  // This is true when the user hits record
-  const [recording, setRecording] = useState(false)
   const [startTime, setStartTime] = useState<number | null>(null)
   const [stopTime, setStopTime] = useState<number | null>(null)
-  // Holds the string id of the new track
-  // if we're already playing a track and need to stop
-  // the old one before we start the new one
-  const [switchTo, setSwitchTo] = useState<string | null>(null)
   // useDexie automatically keys off the primary key of the table.
   // So key is id, value is the track object
   const tracks = useDexieMap<string, Track>('tracks') || new Map()
   const addTrack = useDexiePutItem<Track>('tracks')
-  const audio = useRef<HTMLAudioElement>()
+  const audio = useRef<HTMLAudioElement | null>()
   // This gets filled up with Blobs as mediaRecorder records.
   // We later consolidate it into one Blob, which is the binary data
   // that can be written out as a file
   const chunks = useRef<Blob[]>([])
+  // Holds the stream from getUserMedia once the Promise resolves
+  const mediaRecorder = useRef<MediaRecorder | null>()
 
-  const status = getStatus({
-    audioReady,
-    mediaRecorder: Boolean(mediaRecorder),
-    playing: Boolean(playing),
-    recording,
-    switchTo: Boolean(switchTo),
+  const [state, send] = useStateMachine({
+    initial: State.IDLE,
+    schema: {
+      events: {
+        [Event.ERROR]: t<{ error: unknown; state: State }>(),
+        [Event.PLAY]: t<{ value: string }>(),
+      },
+    },
+    states: {
+      // We aren't doing anything.
+      // No audio is playing, the user isn't waiting for recording to start.
+      [State.IDLE]: {
+        on: {
+          [Event.RECORD]: State.WAITING_ON_MIC_ACCESS,
+          [Event.PLAY]: State.PLAYING,
+        },
+      },
+
+      // This is the first step after the user presses record.
+      // Prompt user for mic access,
+      // then store MediaRecorder in state once we get it
+      // and transition to the RECORDING state.
+      [State.WAITING_ON_MIC_ACCESS]: {
+        effect: ({ send }) => {
+          navigator.mediaDevices
+            .getUserMedia(CONSTRAINTS)
+            .then((stream) => {
+              mediaRecorder.current = new MediaRecorder(stream)
+              send(Event.RECORD)
+            })
+            // The user can deny mic access,
+            // so this may not be an actual error.
+            .catch((err) =>
+              send({
+                error: err,
+                state: State.WAITING_ON_MIC_ACCESS,
+                type: Event.ERROR,
+              })
+            )
+        },
+        on: {
+          [Event.ERROR]: State.ERROR,
+          [Event.RECORD]: State.RECORDING,
+        },
+      },
+
+      // Once we have mic access, start recording.
+      // Also hang onto the start and stop times so we can
+      // calculate duration later.
+      [State.RECORDING]: {
+        effect: ({ send }) => {
+          if (mediaRecorder.current == null) {
+            send({
+              error: 'Tried to start recording but `mediaRecorder` is null!',
+              state: State.RECORDING,
+              type: Event.ERROR,
+            })
+            return
+          }
+
+          mediaRecorder.current.onstart = ({ timeStamp }) =>
+            setStartTime(timeStamp)
+          mediaRecorder.current.onstop = ({ timeStamp }) => {
+            setStopTime(timeStamp)
+            send(Event.AUDIO_READY)
+          }
+          mediaRecorder.current.ondataavailable = ({ data }) =>
+            chunks.current.push(data)
+
+          mediaRecorder.current.start()
+
+          return () => {
+            mediaRecorder.current?.stop()
+          }
+        },
+
+        on: {
+          [Event.ERROR]: State.ERROR,
+          [Event.STOP_RECORDING]: State.FINISHED_RECORDING,
+        },
+      },
+
+      // This is just an intermediate state.
+      // The user has stopped recording,
+      // but we have to wait on mediaRecorder.onstop to fire
+      // before we can save audio, so we wait here.
+      [State.FINISHED_RECORDING]: {
+        on: { [Event.AUDIO_READY]: State.SAVING_AUDIO },
+      },
+
+      // We transition to this state from mediaRecorder.onstop.
+      // Create the final audio track.
+      // Then add it to the list of tracks.
+      [State.SAVING_AUDIO]: {
+        effect: ({ send }) => {
+          const audio = new Blob(chunks.current, {
+            type: mediaRecorder.current?.mimeType,
+          })
+          const track = makeTrack({ audio, duration: stopTime! - startTime! })
+
+          addTrack(track)
+          send(Event.IDLE)
+
+          return () => {
+            mediaRecorder.current = null
+            // If chunks isn't reset, every recording will be cumulative.
+            // It was a funny bug when i was first testing recording.
+            chunks.current = []
+          }
+        },
+        on: { [Event.IDLE]: State.IDLE },
+      },
+
+      // Before i switched to using a state machine,
+      // there was an intermediate state when switching
+      // tracks while playing.
+      // This is no longer required!
+      // The state machine will happily go from
+      // PLAYING -> PLAYING.
+      [State.PLAYING]: {
+        effect: ({ event, send }) => {
+          // If we're already playing a track and
+          // we recieve an event to play another one,
+          // we should clean up the old track first.
+          if (audio.current) {
+            // TODO: Might need to do this? Not sure
+            // audio.current.onended = null;
+          }
+
+          const trackId = event.value
+          const trackToPlay = tracks.get(trackId)
+          if (!trackToPlay) {
+            console.error(
+              `Couldn't get track with id ${trackId} from track list`
+            )
+            send(Event.IDLE)
+            return
+          }
+
+          const url = URL.createObjectURL(trackToPlay.audio)
+
+          audio.current = new Audio(url)
+          audio.current.play()
+          audio.current.onended = () => send(Event.IDLE)
+
+          return () => {
+            if (audio.current) {
+              audio.current.onended = null
+              audio.current.pause()
+              audio.current = null
+            }
+          }
+        },
+        on: {
+          [Event.IDLE]: State.IDLE,
+          [Event.PLAY]: State.PLAYING,
+          [Event.RECORD]: State.WAITING_ON_MIC_ACCESS,
+        },
+      },
+
+      [State.ERROR]: {
+        effect: ({ event, send }) => {
+          if (process.env.NODE_ENV === 'development') {
+            console.log(
+              `Somethin's fucky. The ${event.state} state errored:`,
+              event.error
+            )
+          }
+          send(Event.IDLE)
+        },
+      },
+    },
   })
 
-  useEffect(() => {
-    if (status === Status.IDLE) {
-      audio.current?.pause()
-      return
-    }
-
-    // This is the first step after the user presses record.
-    // Prompt user for mic access,
-    // then store MediaRecorder in state once we get it
-    if (status === Status.WAITING_ON_MIC_ACCESS) {
-      navigator.mediaDevices
-        .getUserMedia(CONSTRAINTS)
-        .then((stream) => {
-          setMediaRecorder(new MediaRecorder(stream))
-        })
-        .catch((err) => console.error(err))
-      return
-    }
-
-    // Once we have mic access, start recording.
-    // Also hang onto the start and stop times so we can
-    // calculate duration later
-    if (status === Status.RECORDING) {
-      // If a track is playing when the user hits record,
-      // we want to stop it
-      audio.current?.pause()
-
-      mediaRecorder!.onstart = ({ timeStamp }) => setStartTime(timeStamp)
-      mediaRecorder!.onstop = ({ timeStamp }) => {
-        setAudioReady(true)
-        setStopTime(timeStamp)
-      }
-      mediaRecorder!.ondataavailable = ({ data }) => chunks.current.push(data)
-
-      mediaRecorder!.start()
-      return
-    }
-
-    if (status === Status.FINISHED_RECORDING) {
-      // TODO: Remove these !s by typeguarding correctly
-      mediaRecorder!.stop()
-    }
-
-    // This waits for mediaRecorder.onstop to fire.
-    // Create the final audio track.
-    // Then add it to the list of tracks
-    if (status === Status.SAVING_AUDIO) {
-      const audio = new Blob(chunks.current, {
-        type: mediaRecorder!.mimeType,
-      })
-      const track = makeTrack({ audio, duration: stopTime! - startTime! })
-
-      addTrack(track)
-      setMediaRecorder(null)
-      setAudioReady(false)
-      // If chunks isn't reset, every recording will be cumulative.
-      // It was a funny bug when i was first testing recording
-      chunks.current = []
-      return
-    }
-
-    if (status === Status.SWITCHING_TRACKS) {
-      audio.current?.pause()
-      setPlaying(switchTo)
-      setSwitchTo(null)
-      return
-    }
-
-    if (status === Status.PLAYING) {
-      const trackToPlay = tracks.get(playing!)
-      if (!trackToPlay) {
-        console.error(`Couldn't get track with id ${playing} from track list`)
-        return
-      }
-
-      const url = URL.createObjectURL(trackToPlay.audio)
-      audio.current = new Audio(url)
-      audio.current.play()
-      audio.current.onended = () => setPlaying(null)
-      return
-    }
-  }, [status])
-
   return {
-    play: (trackId: string) => {
-      setRecording(false)
-      if (playing) {
-        setSwitchTo(trackId)
-      } else {
-        setPlaying(trackId)
-      }
-    },
-    status,
+    play: (trackId: string) => send({ type: Event.PLAY, value: trackId }),
+    status: state.value,
     toggleRecord: () => {
-      setPlaying(null)
-      setRecording((r) => !r)
+      if (state.value === State.RECORDING) {
+        send(Event.STOP_RECORDING)
+      } else {
+        send(Event.RECORD)
+      }
     },
     tracks: Array.from(tracks.values()),
   }


### PR DESCRIPTION
the first implementation of useAudioEngine worked well, but i didn't like how the state was broken up across multiple useState calls, or how the logic to determine the status was quite far away from the effects

useStateMachine's interface is much better - the states, transitions, and effects are all colocated.
having a proper state machine with event-based transitions also let me simplify the hook's state and the number of states